### PR TITLE
Bump gradle version plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'net.nemerosa.versioning' version '2.14.0'
+    id 'net.nemerosa.versioning' version '3.1.0'
 }
 
 group 'com.1password.burp-analyzer'


### PR DESCRIPTION
Fixes #9 by bumping the versioning dependency that was pulling in unavailable dependencies.