### PR TITLE
Updates for Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Run unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ You might wonder how you obtain the session key from your session on 1Password.c
 
 ## How to build yourself
 
-Make sure you to install Java 17 on your computer. E.g. to install the Eclipse Foundation's OpenJDK 17, on a Mac with Homebrew, run:
+Make sure you to install Java 21 on your computer. E.g. to install the Eclipse Foundation's OpenJDK 21, on a Mac with Homebrew, run:
 ```shell
 brew tap homebrew/cask-versions
-brew install temurin17
+brew install temurin21
 ```
 
 `./gradlew fatJar` builds this plugin and puts the resulting JAR file in `build/libs`.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'net.nemerosa.versioning' version '3.1.0'
 }
 
-group 'com.1password.burp-analyzer'
+group = 'com.1password.burp-analyzer'
 
 repositories {
     mavenCentral()
@@ -29,7 +29,11 @@ versioning {
     }
 }
 
-version versioning.ext.makeVersion()
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ["-Xlint:deprecation", "-Xlint:unchecked"]
+}
+
+version = versioning.ext.makeVersion()
 
 task fatJar(type: Jar) {
     duplicatesStrategy = 'exclude'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/onepassword/burpanalyzer/RequestMACTests.java
+++ b/src/test/java/com/onepassword/burpanalyzer/RequestMACTests.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Base64;
 import java.util.List;
@@ -32,30 +34,30 @@ public class RequestMACTests {
     private final byte[] sessionKey;
 
     @Parameterized.Parameters
-    public static List<Object[]> data() throws MalformedURLException {
+    public static List<Object[]> data() throws URISyntaxException, MalformedURLException {
         return List.of(
             new Object[]{"v1|6|oBnE8JLpG2Othzgy",
                     "RDPMIFQWUJBWZFDBKURHNRFVRA", 6L, RequestMethod.GET,
-                    new URL("https://my.b5local.com:3000/api/v1/invites"),
+                    new URI("https://my.b5local.com:3000/api/v1/invites").toURL(),
                     Base64.getUrlDecoder().decode("ETmGs4U7ReMolW1J64ZAmmksXbQFFbeyRPW6zPWj3VM")
             },
             new Object[] {"v1|7|E2w1PDPlDRKaVEQs",
                     "RDPMIFQWUJBWZFDBKURHNRFVRA", 7L, RequestMethod.GET,
-                    new URL("https://my.b5local.com:3000/api/v2/users?limit=25&states=P&types=G,R"),
+                    new URI("https://my.b5local.com:3000/api/v2/users?limit=25&states=P&types=G,R").toURL(),
                     Base64.getUrlDecoder().decode("ETmGs4U7ReMolW1J64ZAmmksXbQFFbeyRPW6zPWj3VM")
             },
             new Object[] { "v1|7|JDqt1exoqPCjZiAJ",
                     "QVLABIG34RB3TMH7ZJEW47CCKE", 7L, RequestMethod.GET,
-                    new URL("https://my.b5local.com:3000/api/v1/vaults?permission=read&attrs=accessor-previews%2Ccombined-access"),
+                    new URI("https://my.b5local.com:3000/api/v1/vaults?permission=read&attrs=accessor-previews%2Ccombined-access").toURL(),
                     Base64.getUrlDecoder().decode("-K_oZ-mtamTiLJODQn5cVhXQX-nFmPI2kosmWmOWfZg") },
             new Object[]{"v1|3907223784|Htb-Sn_9k4u59wOz",
                     "VADBXWG7FVC6FIOKOJ4DBGE4SY", 3907223784L, RequestMethod.DELETE,
-                    new URL("https://awesome.b5dev.com/api/v1/vault/p3nfd4jax622nqjos7licewuyn"),
+                    new URI("https://awesome.b5dev.com/api/v1/vault/p3nfd4jax622nqjos7licewuyn").toURL(),
                     Base64.getUrlDecoder().decode("xvoJlJo7KkJGQ55-mjd7tOBE6YvRYnGBNpPoo3_F2M0")
             },
             new Object[]{"v1|781158249|kkvpSd6stufwwlsZ",
                     "2UG2ZGCDLFAWRHPETAV325EL5U", 781158249L, RequestMethod.GET,
-                    new URL("https://awesome.b5dev.com/api/v1/auditevents/0/older?object_types=gva,invite"),
+                    new URI("https://awesome.b5dev.com/api/v1/auditevents/0/older?object_types=gva,invite").toURL(),
                     Base64.getUrlDecoder().decode("WDs9nvg0DYYmQmucwPZ25FV6uUSaYsJUgse7apbs6rk")
             }
         );


### PR DESCRIPTION
This is minor maintenance so the plugin so be built with Java 21 (which is the latest LTS Java as of this PR), and the pipelines also use Java 21 to build it.

Overview of changes:
* Updated Gradle bundle to 8.14.1
* Addressed Gradle deprecation warnings
* Tested building with Java 21
* Enabled logging deprecation and safety warnings for Gradle Java compiles
* Addressed a deprecation warning for how URLs are constructed in a test file
* Updated the Java version in the GitHub Actions and README
* Also updated the Ubuntu version the GitHub Action uses